### PR TITLE
Avoid using the ambiguous \h shorthand character

### DIFF
--- a/Syntaxes/Cython.tmLanguage
+++ b/Syntaxes/Cython.tmLanguage
@@ -57,13 +57,13 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>\b(?i:(0x\h*)L)</string>
+			<string>\b(?i:(0x[0-9A-Fa-f]*)L)</string>
 			<key>name</key>
 			<string>constant.numeric.integer.long.hexadecimal.cython</string>
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>\b(?i:(0x\h*))</string>
+			<string>\b(?i:(0x[0-9A-Fa-f]*))</string>
 			<key>name</key>
 			<string>constant.numeric.integer.hexadecimal.cython</string>
 		</dict>


### PR DESCRIPTION
Depending on the regular expression engine used, \h does not always
mean the same. With a PCRE engine, it matches white spaces, whereas,
with a Oniguruma engine, it matches hexademical digit characters.
Atom uses an Oniguruma engine, but github.com relies on a PCRE
engine.